### PR TITLE
ユーザー設定画面を用意した

### DIFF
--- a/src/app/actions/userActions.ts
+++ b/src/app/actions/userActions.ts
@@ -1,8 +1,10 @@
 "use server";
 
+import { urls } from "@/consts/urls";
 import { AppRouter } from "@/trpc/routers/_app";
 import { trpc } from "@/trpc/server";
 import { inferRouterInputs } from "@trpc/server";
+import { revalidatePath } from "next/cache";
 
 export const getCurrentUser = async () => {
   return await trpc.user.getCurrentUser();
@@ -11,7 +13,12 @@ export const getCurrentUser = async () => {
 export const updateUserName = async ({
   name,
 }: inferRouterInputs<AppRouter>["user"]["updateUserName"]) => {
-  return await trpc.user.updateUserName({
+  const result = await trpc.user.updateUserName({
     name,
   });
+
+  // ダッシュボード関連のパスを再検証して、getCurrentUserのデータを再取得
+  revalidatePath(urls.dashboard);
+
+  return result;
 };

--- a/src/app/actions/userActions.ts
+++ b/src/app/actions/userActions.ts
@@ -4,8 +4,14 @@ import { AppRouter } from "@/trpc/routers/_app";
 import { trpc } from "@/trpc/server";
 import { inferRouterInputs } from "@trpc/server";
 
-export const getCurrentUser = async (
-  args: inferRouterInputs<AppRouter>["user"]["getCurrentUser"]
-) => {
-  return await trpc.user.getCurrentUser(args);
+export const getCurrentUser = async () => {
+  return await trpc.user.getCurrentUser();
+};
+
+export const updateUserName = async ({
+  name,
+}: inferRouterInputs<AppRouter>["user"]["updateUserName"]) => {
+  return await trpc.user.updateUserName({
+    name,
+  });
 };

--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,12 +1,18 @@
+import { getCurrentUser } from "@/app/actions/userActions";
 import { PostTimeLine } from "@/components/feature/threadDetail/PostTimeLine";
 import { ThreadInformation } from "@/components/feature/threadDetail/ThreadInformation";
 import { Skeleton } from "@/components/ui/skeleton";
+import { urls } from "@/consts/urls";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 type Props = { params: Promise<{ id: string }> };
 
 export default async function Page({ params }: Props) {
   const { id: threadId } = await params;
+
+  const currentUser = await getCurrentUser();
+  if (!currentUser) redirect(urls.top);
 
   return (
     <div className="h-full relative">

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,9 +2,7 @@ import { DashboardNavigation } from "@/components/feature/dashboard/DashboardNav
 import { DashBoardSidebar } from "@/components/feature/layout/Sidebar";
 import { generateMetadataObject } from "@/lib/generateMetadataObject";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
 import type React from "react";
-import { getCurrentUser } from "../actions/userActions";
 
 export const metadata: Metadata = generateMetadataObject({
   title: "Thread Note - ダッシュボード",
@@ -15,12 +13,6 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const currentUser = await getCurrentUser();
-
-  if (!currentUser) {
-    return notFound();
-  }
-
   return (
     <>
       <DashboardNavigation />

--- a/src/app/dashboard/new/page.tsx
+++ b/src/app/dashboard/new/page.tsx
@@ -1,3 +1,4 @@
+import { getCurrentUser } from "@/app/actions/userActions";
 import { CreateNewThreadForm } from "@/components/feature/newThread/CreateNewThreadForm";
 import {
   Breadcrumb,
@@ -8,8 +9,12 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { urls } from "@/consts/urls";
+import { redirect } from "next/navigation";
 
 export default async function Page() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) redirect(urls.top);
+
   return (
     <div className="flex h-full">
       <main className="flex-1 overflow-auto border-r md:px-6 px-2 md:pt-6 pt-4 pb-4">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,29 @@
+import { getCurrentUser } from "@/app/actions/userActions";
+import { UpdateUserNameForm } from "@/components/feature/settings/UpdateUserNameForm";
+import { urls } from "@/consts/urls";
+import { generateMetadataObject } from "@/lib/generateMetadataObject";
+import { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+export const metadata: Metadata = generateMetadataObject({
+  title: "Thread Note - 設定",
+});
+
+export default async function SettingsPage() {
+  const currentUser = await getCurrentUser();
+  if (!currentUser) redirect(urls.top);
+
+  return (
+    <div className="flex h-full">
+      <main className="flex-1 overflow-auto border-r md:px-6 px-2 md:pt-6 pt-4 pb-4">
+        <div className="flex flex-col space-y-4 max-w-[700px] mx-auto">
+          <h1 className="text-2xl font-bold mb-6">設定</h1>
+          <div className="bg-white p-6 rounded-lg shadow-sm">
+            <h2 className="text-xl font-semibold mb-4">プロフィール設定</h2>
+            <UpdateUserNameForm currentUser={currentUser} />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/feature/layout/Sidebar/index.tsx
+++ b/src/components/feature/layout/Sidebar/index.tsx
@@ -2,7 +2,7 @@ import { getCurrentUser } from "@/app/actions/userActions";
 import { UserIcon } from "@/components/model/user/UserIcon";
 import { urls } from "@/consts/urls";
 import { cn } from "@/lib/utils";
-import { Home, Pen } from "lucide-react";
+import { Home, Pen, Settings } from "lucide-react";
 import Link from "next/link";
 import { SidebarThreadList } from "../../dashboard/SidebarThreadList";
 
@@ -18,6 +18,11 @@ export const DashBoardSidebar = async () => {
       href: urls.dashboardThreadNew,
       label: "New",
       icon: Pen,
+    },
+    {
+      href: urls.dashboardSettings,
+      label: "Settings",
+      icon: Settings,
     },
     // {
     //   href: "/explore",
@@ -38,11 +43,6 @@ export const DashBoardSidebar = async () => {
     //   href: "/archived",
     //   label: "Archived",
     //   icon: Archive,
-    // },
-    // {
-    //   href: "/settings",
-    //   label: "Settings",
-    //   icon: Settings,
     // },
   ];
 

--- a/src/components/feature/settings/UpdateUserNameForm/index.tsx
+++ b/src/components/feature/settings/UpdateUserNameForm/index.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { updateUserName } from "@/app/actions/userActions";
+import { UserIcon } from "@/components/model/user/UserIcon";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useServerAction } from "@/lib/useServerAction";
+import { trpc } from "@/trpc/client";
+import { User } from "@prisma/client";
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface UpdateUserNameFormProps {
+  currentUser: User;
+}
+
+export function UpdateUserNameForm({ currentUser }: UpdateUserNameFormProps) {
+  const utils = trpc.useUtils();
+  const [name, setName] = useState(currentUser.name || "");
+  const { isPending, enqueueServerAction } = useServerAction();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) {
+      toast.error("名前を入力してください");
+      return;
+    }
+
+    enqueueServerAction({
+      action: () => updateUserName({ name }),
+      error: {
+        text: "名前の更新に失敗しました",
+      },
+      success: {
+        onSuccess: () => utils.user.getCurrentUser.invalidate(),
+        text: "名前を更新しました",
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center space-x-4">
+        <UserIcon userImage={currentUser.image} size="md" />
+        <div className="flex-1">
+          <label
+            htmlFor="name"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            名前
+          </label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="名前を入力してください"
+            className="max-w-md"
+          />
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Button type="submit" disabled={isPending || name === currentUser.name}>
+          {isPending ? "更新中..." : "更新"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -1,6 +1,8 @@
 export const urls = {
+  top: "/",
   dashboard: "/dashboard",
   dashboardWithQuery: (page: number) => `/dashboard?page=${page}`,
   dashboardThreadNew: "/dashboard/new",
   dashboardThreadDetails: (id: string) => `/dashboard/${id}`,
+  dashboardSettings: "/dashboard/settings",
 };

--- a/src/trpc/routers/userRouter.ts
+++ b/src/trpc/routers/userRouter.ts
@@ -1,7 +1,27 @@
-import { baseProcedure, router } from "../init";
+import { prisma } from "@/prisma";
+import { UserSchema } from "@/types/src/domains";
+import { z } from "zod";
+import { baseProcedure, protectedProcedure, router } from "../init";
 
 export const userRouter = router({
   getCurrentUser: baseProcedure.query(async ({ ctx }) => {
     return ctx.currentUser;
   }),
+
+  updateUserName: protectedProcedure
+    .input(
+      z.object({
+        name: UserSchema.shape.name,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return await prisma.user.update({
+        where: {
+          id: ctx.currentUser.id,
+        },
+        data: {
+          name: input.name,
+        },
+      });
+    }),
 });

--- a/src/trpc/usecases/threadDetail/GenerateReplyPostsUseCase/index.ts
+++ b/src/trpc/usecases/threadDetail/GenerateReplyPostsUseCase/index.ts
@@ -3,7 +3,7 @@ import type { Post, User } from "@prisma/client";
 import OpenAI from "openai";
 
 const openai = new OpenAI({
-  apiKey: process.env["OPENAI_API_KEY"],
+  apiKey: process.env["OPENAI_API_KEY"] || "",
 });
 
 export class GenerateReplyPostsUseCase {


### PR DESCRIPTION
## 対象の Issue

Fix: ユーザー設定画面を用意した

## 変更点(UI の変更があればスクリーンショットも)

![localhost_3000_dashboard_settings(iPhone SE)](https://github.com/user-attachments/assets/60c5f23a-4d6a-4dbf-b2d7-56db60ff4713)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a dashboard settings page where users can update their profile name.
  - Added a new "Settings" option in the sidebar for quick access.
  - Enhanced page security with authentication checks that redirect unauthenticated users to the homepage.
  - Added functionality for users to update their username through a dedicated form.

- **Improvements**
  - Simplified the function for retrieving the current user.
  - Expanded URL constants for improved routing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->