### PR TITLE
85 画像をクリックして拡大するUIにする

### DIFF
--- a/src/components/ui/MarkdownViewer/Image.tsx
+++ b/src/components/ui/MarkdownViewer/Image.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+
+type Props = {
+  src: string | undefined;
+  alt: string | undefined;
+};
+
+export const Image = ({ src, alt }: Props) => {
+  const [expand, setExpand] = useState(false);
+
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt}
+        className={
+          "max-w-full h-auto rounded-lg shadow-md mx-auto border cursor-zoom-in transition-transform transform hover:scale-105"
+        }
+        onClick={() => setExpand(true)}
+      />
+      <div
+        className={`fixed top-0 left-0 w-full h-full bg-black/80 flex items-center justify-center z-100 ${
+          expand
+            ? "opacity-100 pointer-events-auto cursor-zoom-out"
+            : "opacity-0 pointer-events-none"
+        } transition-opacity`}
+        onClick={() => setExpand(false)}
+      >
+        <div className="absolute top-0 w-screen p-2">
+          <span className="text-white text-sm font-bold">{alt}</span>
+        </div>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt={alt} className="max-h-full max-w-full" />
+      </div>
+    </>
+  );
+};

--- a/src/components/ui/MarkdownViewer/Image.tsx
+++ b/src/components/ui/MarkdownViewer/Image.tsx
@@ -15,7 +15,7 @@ export const Image = ({ src, alt }: Props) => {
         src={src}
         alt={alt}
         className={
-          "max-w-full h-auto rounded-lg shadow-md mx-auto border cursor-zoom-in transition-transform transform hover:scale-105"
+          "max-w-full max-h-100 rounded-lg shadow-md mx-auto border cursor-zoom-in transition-transform transform hover:scale-105"
         }
         onClick={() => setExpand(true)}
       />

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -34,7 +34,7 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             }
           }
 
-          return <p className="text-gray-700 leading-relaxed">{children}</p>;
+          return <p className="text-gray-800">{children}</p>;
         },
         ul: ({ children }) => (
           <ul className="list-disc ml-5 space-y-1">{children}</ul>

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -2,6 +2,7 @@ import { OgpCard } from "@/components/ui/MarkdownViewer/OgpCard";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import { Image } from "./Image";
 
 export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
   return (
@@ -84,14 +85,7 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             {children}
           </a>
         ),
-        img: ({ src, alt }) => (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={src}
-            alt={alt}
-            className="max-w-full h-auto rounded-lg shadow-md mx-auto border"
-          />
-        ),
+        img: ({ src, alt }) => <Image src={src} alt={alt} />,
       }}
     >
       {body}


### PR DESCRIPTION
## 対象の Issue

Fix:

## 変更点(UI の変更があればスクリーンショットも)

- 
![localhost_3000_dashboard_fb0aa3a3-74bf-4dea-ac6f-828f71750e19(iPhone 6_7_8)](https://github.com/user-attachments/assets/7096d50f-ee89-43b4-8eb8-4cbde1c55dc9)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive image viewer that allows images to expand into an overlay with a smooth transition, displaying a caption for enhanced viewing.
  
- **Style**
  - Updated the text styling within the Markdown viewer for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->