### PR TITLE
Fix OGP card to not display image if not available

### DIFF
--- a/src/components/ui/MarkdownViewer/OgpCard.tsx
+++ b/src/components/ui/MarkdownViewer/OgpCard.tsx
@@ -64,12 +64,14 @@ export const OgpCard = ({ url }: Props) => {
             </p>
           </div>
         </div>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={data?.image || "/no-image.png"}
-          alt={data?.title || url}
-          className="w-30 md:w-50 h-31 object-cover"
-        />
+        {data?.image && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.image}
+            alt={data?.title || url}
+            className="w-30 md:w-50 h-31 object-cover"
+          />
+        )}
       </div>
     </a>
   );


### PR DESCRIPTION
Fixes #87

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itizawa/thread-note/pull/88?shareId=7b66644e-d53c-437e-8cb8-9fc6a96dbdce).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the card's image display so that images appear only when valid data is present, removing the generic placeholder image. The alternative text remains unchanged for accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->