### PR TITLE
Expand YouTube videos in Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.7.4",
     "@neondatabase/serverless": "^0.10.4",
+    "@next/third-parties": "^15.2.2",
     "@prisma/adapter-neon": "^6.3.1",
     "@prisma/client": "^6.3.1",
     "@radix-ui/react-avatar": "^1.1.3",
@@ -43,7 +44,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.482.0",
-    "next": "15.2.2",
+    "next": "^15.2.2",
     "next-auth": "^5.0.0-beta.25",
     "next-themes": "^0.4.4",
     "open-graph-scraper": "^6.9.0",

--- a/src/components/ui/MarkdownViewer/OgpCard.tsx
+++ b/src/components/ui/MarkdownViewer/OgpCard.tsx
@@ -1,12 +1,18 @@
 "use client";
 
 import { trpc } from "@/trpc/client";
+import { YouTube } from "@next/third-parties/google";
 
 type Props = {
   url: string;
 };
 
 export const OgpCard = ({ url }: Props) => {
+  if (url.includes("youtube.com/watch")) {
+    const videoId = url.split("v=")[1];
+    return <YouTube videoId={videoId} />;
+  }
+
   const { data, isLoading } = trpc.ogp.fetchByUrl.useQuery({ url });
 
   if (isLoading) {

--- a/src/components/ui/MarkdownViewer/OgpCard.tsx
+++ b/src/components/ui/MarkdownViewer/OgpCard.tsx
@@ -1,18 +1,12 @@
 "use client";
 
 import { trpc } from "@/trpc/client";
-import { YouTube } from "@next/third-parties/google";
 
 type Props = {
   url: string;
 };
 
 export const OgpCard = ({ url }: Props) => {
-  if (url.includes("youtube.com/watch")) {
-    const videoId = url.split("v=")[1];
-    return <YouTube videoId={videoId} />;
-  }
-
   const { data, isLoading } = trpc.ogp.fetchByUrl.useQuery({ url });
 
   if (isLoading) {

--- a/src/components/ui/MarkdownViewer/YouTubeCard.tsx
+++ b/src/components/ui/MarkdownViewer/YouTubeCard.tsx
@@ -3,9 +3,19 @@
 import { YouTubeEmbed } from "@next/third-parties/google";
 
 type Props = {
-  videoid: string;
+  url: string;
 };
 
-export const YouTubeCard = ({ videoid }: Props) => {
-  return <YouTubeEmbed videoid={videoid} />;
+export const YouTubeCard = ({ url }: Props) => {
+  let videoId: string | null;
+  if (url.includes("shorts/")) {
+    videoId = url.split("shorts/")[1].split("?")[0];
+  } else {
+    const urlParams = new URLSearchParams(new URL(url).search);
+    videoId = urlParams.get("v");
+  }
+
+  if (!videoId) return null;
+
+  return <YouTubeEmbed videoid={videoId} />;
 };

--- a/src/components/ui/MarkdownViewer/YouTubeCard.tsx
+++ b/src/components/ui/MarkdownViewer/YouTubeCard.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { YouTubeEmbed } from "@next/third-parties/google";
+
+type Props = {
+  videoid: string;
+};
+
+export const YouTubeCard = ({ videoid }: Props) => {
+  return <YouTubeEmbed videoid={videoid} />;
+};

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -32,13 +32,14 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             child.properties.href === child.children[0].value
           ) {
             if (/(https?:\/\/[^\s]+)/g.test(child.properties.href)) {
-              if (child.properties.href.includes("youtube.com/watch")) {
-                const videoId = child.properties.href.split("v=").pop(); // Use pop() to accommodate any additional parameters
-                if (!videoId) return null;
-
-                return <YouTubeCard videoid={videoId} />;
+              const url = child.properties.href;
+              if (
+                url.includes("youtube.com/watch") ||
+                url.includes("youtube.com/shorts")
+              ) {
+                return <YouTubeCard url={url} />;
               }
-              return <OgpCard url={child.properties.href} />;
+              return <OgpCard url={url} />;
             }
           }
 

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -3,24 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { Image } from "./Image";
-import { YouTube } from "@next/third-parties/google";
-
-const YouTubeEmbed: React.FC<{ url: string }> = ({ url }) => {
-  const videoId = url.split("v=")[1];
-  const embedUrl = `https://www.youtube.com/embed/${videoId}`;
-  return (
-    <div className="youtube-embed">
-      <iframe
-        width="560"
-        height="315"
-        src={embedUrl}
-        frameBorder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowFullScreen
-      ></iframe>
-    </div>
-  );
-};
+import { YouTubeCard } from "./YouTubeCard";
 
 export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
   return (
@@ -49,8 +32,12 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             child.properties.href === child.children[0].value
           ) {
             if (/(https?:\/\/[^\s]+)/g.test(child.properties.href)) {
+              console.log(child.properties.href);
               if (child.properties.href.includes("youtube.com/watch")) {
-                return <YouTubeEmbed url={child.properties.href} />;
+                const videoId = child.properties.href.split("v=").pop(); // Use pop() to accommodate any additional parameters
+                if (!videoId) return null;
+
+                return <YouTubeCard videoid={videoId} />;
               }
               return <OgpCard url={child.properties.href} />;
             }

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -32,7 +32,6 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             child.properties.href === child.children[0].value
           ) {
             if (/(https?:\/\/[^\s]+)/g.test(child.properties.href)) {
-              console.log(child.properties.href);
               if (child.properties.href.includes("youtube.com/watch")) {
                 const videoId = child.properties.href.split("v=").pop(); // Use pop() to accommodate any additional parameters
                 if (!videoId) return null;

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -3,9 +3,9 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { Image } from "./Image";
-import { YouTube } from "@next/third-parties/google"; // P224a
+import { YouTube } from "@next/third-parties/google";
 
-const YouTubeEmbed: React.FC<{ url: string }> = ({ url }) => { // P99aa
+const YouTubeEmbed: React.FC<{ url: string }> = ({ url }) => {
   const videoId = url.split("v=")[1];
   const embedUrl = `https://www.youtube.com/embed/${videoId}`;
   return (
@@ -49,7 +49,7 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             child.properties.href === child.children[0].value
           ) {
             if (/(https?:\/\/[^\s]+)/g.test(child.properties.href)) {
-              if (child.properties.href.includes("youtube.com/watch")) { // Pfd87
+              if (child.properties.href.includes("youtube.com/watch")) {
                 return <YouTubeEmbed url={child.properties.href} />;
               }
               return <OgpCard url={child.properties.href} />;

--- a/src/components/ui/MarkdownViewer/index.tsx
+++ b/src/components/ui/MarkdownViewer/index.tsx
@@ -3,6 +3,24 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { Image } from "./Image";
+import { YouTube } from "@next/third-parties/google"; // P224a
+
+const YouTubeEmbed: React.FC<{ url: string }> = ({ url }) => { // P99aa
+  const videoId = url.split("v=")[1];
+  const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+  return (
+    <div className="youtube-embed">
+      <iframe
+        width="560"
+        height="315"
+        src={embedUrl}
+        frameBorder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      ></iframe>
+    </div>
+  );
+};
 
 export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
   return (
@@ -31,6 +49,9 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             child.properties.href === child.children[0].value
           ) {
             if (/(https?:\/\/[^\s]+)/g.test(child.properties.href)) {
+              if (child.properties.href.includes("youtube.com/watch")) { // Pfd87
+                return <YouTubeEmbed url={child.properties.href} />;
+              }
               return <OgpCard url={child.properties.href} />;
             }
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,6 +511,13 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.2.tgz#2072d69374f8c944134a5c5a80ce03ff84254cfa"
   integrity sha512-52nWy65S/R6/kejz3jpvHAjZDPKIbEQu4x9jDBzmB9jJfuOy5rspjKu4u77+fI4M/WzLXrrQd57hlFGzz1ubcQ==
 
+"@next/third-parties@^15.2.2":
+  version "15.2.2"
+  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-15.2.2.tgz#cf03362dc7c682ff4540c4aee01f1cd8e9843658"
+  integrity sha512-MLytjU67N5HdIq0Ch8kSB7EGL9JWZaT8C4YzSzjWRTXbf67G3m9Om+ziKqItEnkUNWZeYRzdn1VsDCpcUaIUwg==
+  dependencies:
+    third-party-capital "1.0.20"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -4656,7 +4663,7 @@ next-themes@^0.4.4:
   resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.4.6.tgz#8d7e92d03b8fea6582892a50a928c9b23502e8b6"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-next@15.2.2:
+next@^15.2.2:
   version "15.2.2"
   resolved "https://registry.yarnpkg.com/next/-/next-15.2.2.tgz#e3941a0e0e76cfe1880b57452807489e0546e3a2"
   integrity sha512-dgp8Kcx5XZRjMw2KNwBtUzhngRaURPioxoNIVl5BOyJbhi9CUgEtKDO7fx5wh8Z8vOVX1nYZ9meawJoRrlASYA==
@@ -6131,6 +6138,11 @@ terminal-link@2.1.1:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
+
+third-party-capital@1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/third-party-capital/-/third-party-capital-1.0.20.tgz#e218a929a35bf4d2245da9addb8ab978d2f41685"
+  integrity sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==
 
 throttleit@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Related to #89

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itizawa/thread-note/pull/90?shareId=068de585-83f5-4eda-b55d-120a9c232e6c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced markdown content display now automatically embeds YouTube videos when links are detected.
  - Introduced a new `YouTubeCard` component to handle YouTube video rendering.

- **Chores**
  - Updated dependencies to support flexible versioning and improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->