### PR TITLE
Sort sidebar threads by most recent message update date

### DIFF
--- a/prisma/migrations/20250316023050_add_last_posted_at/migration.sql
+++ b/prisma/migrations/20250316023050_add_last_posted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "threads" ADD COLUMN     "last_post_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20250316023715_add_index/migration.sql
+++ b/prisma/migrations/20250316023715_add_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "threads_user_id_idx" ON "threads"("user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,10 +113,12 @@ model Thread {
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  lastPostedAt DateTime @default(now()) @map("last_post_at") @db.Timestamptz()
 
   posts Post[]
 
   @@map("threads")
+  @@index([userId])
 }
 
 

--- a/src/components/feature/dashboard/SidebarThreadList/index.tsx
+++ b/src/components/feature/dashboard/SidebarThreadList/index.tsx
@@ -39,8 +39,7 @@ export function SidebarThreadList({
           loadingRenderer={() => <PostListItemSkeleton />}
           loadMore={fetchNextPage}
           hasNextPage={hasNextPage}
-          isLoading={isLoading}
-          isFetching={isFetching}
+          isLoading={isLoading || isFetching}
           rowHeight={36}
           noRowsRenderer={() => (
             <div className="p-2 text-center text-gray-500">

--- a/src/components/feature/dashboard/SidebarThreadList/index.tsx
+++ b/src/components/feature/dashboard/SidebarThreadList/index.tsx
@@ -18,14 +18,18 @@ export function SidebarThreadList({
 }) {
   const { data, hasNextPage, fetchNextPage, isLoading, isFetching } =
     trpc.thread.listThreadsByUserId.useInfiniteQuery(
-      { userId: currentUserId, limit: 20 },
+      {
+        userId: currentUserId,
+        limit: 20,
+        sort: { type: "lastPostedAt", direction: "desc" },
+      },
       { getNextPageParam: (lastPage) => lastPage.nextCursor }
     );
   const threads = data?.pages.flatMap((v) => v.threads) || [];
 
   return (
     <div className="overflow-y-auto flex flex-col flex-1">
-      <div className="p-2">
+      <div className="p-2 ">
         <h2 className="text-sm font-bold">スレッド一覧</h2>
       </div>
       <div className="flex-1">

--- a/src/components/feature/dashboard/ThreadList/index.tsx
+++ b/src/components/feature/dashboard/ThreadList/index.tsx
@@ -107,8 +107,7 @@ export function ThreadList({ currentUserId }: { currentUserId: string }) {
             loadingRenderer={() => <PostListItemSkeleton />}
             loadMore={fetchNextPage}
             hasNextPage={hasNextPage}
-            isLoading={isLoading}
-            isFetching={isFetching}
+            isLoading={isLoading || isFetching}
             rowHeight={72}
             noRowsRenderer={() => (
               <div className="px-2 py-8 text-center text-gray-500">

--- a/src/components/feature/dashboard/ThreadList/index.tsx
+++ b/src/components/feature/dashboard/ThreadList/index.tsx
@@ -3,6 +3,13 @@
 import { UserIcon } from "@/components/model/user/UserIcon";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { VirtualizedList } from "@/components/ui/virtualizedList";
 import { urls } from "@/consts/urls";
 import { trpc } from "@/trpc/client";
@@ -19,6 +26,9 @@ type Thread =
 export function ThreadList({ currentUserId }: { currentUserId: string }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+  const [sortOrder, setSortOrder] = useState<"createdAt" | "lastPostedAt">(
+    "lastPostedAt"
+  );
 
   // 検索クエリのデバウンス処理
   useEffect(() => {
@@ -36,6 +46,10 @@ export function ThreadList({ currentUserId }: { currentUserId: string }) {
         userId: currentUserId,
         searchQuery: debouncedSearchQuery,
         limit: 20,
+        sort: {
+          type: sortOrder,
+          direction: "desc",
+        },
       },
       {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -65,8 +79,26 @@ export function ThreadList({ currentUserId }: { currentUserId: string }) {
         </Link>
       </div>
       <div className="overflow-y-auto flex flex-col rounded-lg border bg-white flex-1">
-        <div className="border-b px-4 py-3">
+        <div className="border-b px-4 py-3 flex items-center justify-between">
           <h2 className="font-medium">スレッド一覧</h2>
+          <Select
+            onValueChange={(value) =>
+              setSortOrder(value as "createdAt" | "lastPostedAt")
+            }
+            defaultValue="lastPostedAt"
+          >
+            <SelectTrigger className="w-fit shadow-none cursor-pointer">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="createdAt" className="cursor-pointer">
+                作成日順
+              </SelectItem>
+              <SelectItem value="lastPostedAt" className="cursor-pointer">
+                更新日順
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </div>
         <div className="flex-1">
           <VirtualizedList

--- a/src/components/feature/threadDetail/CreateNewPostForm/index.tsx
+++ b/src/components/feature/threadDetail/CreateNewPostForm/index.tsx
@@ -19,7 +19,10 @@ export function CreateNewPostForm({ threadId }: Props) {
 
   const handleSubmit = () => {
     enqueueServerAction({
-      action: () => createPostInThread({ threadId, body }),
+      action: async () => {
+        const post = await createPostInThread({ threadId, body });
+        utils.thread.listThreadsByUserId.invalidate({ userId: post.userId });
+      },
       error: {
         text: "更新に失敗しました",
       },

--- a/src/components/feature/threadDetail/PostPaper/ReplyForm/index.tsx
+++ b/src/components/feature/threadDetail/PostPaper/ReplyForm/index.tsx
@@ -30,8 +30,13 @@ export function ReplyForm({ threadId, parentPostId }: Props) {
 
   const handleSubmit = () => {
     enqueueServerAction({
-      action: () => {
-        return createPostInThread({ threadId, body, parentId: parentPostId });
+      action: async () => {
+        const post = await createPostInThread({
+          threadId,
+          body,
+          parentId: parentPostId,
+        });
+        utils.thread.listThreadsByUserId.invalidate({ userId: post.userId });
       },
       error: {
         text: "更新に失敗しました",

--- a/src/components/ui/virtualizedList.tsx
+++ b/src/components/ui/virtualizedList.tsx
@@ -10,7 +10,6 @@ type VirtualizedListProps<T> = {
   loadMore: () => void;
   hasNextPage: boolean;
   isLoading: boolean;
-  isFetching: boolean;
   rowHeight?: number;
 };
 
@@ -21,12 +20,11 @@ export function VirtualizedList<T>({
   loadMore,
   hasNextPage,
   isLoading,
-  isFetching,
   rowHeight = 50,
   noRowsRenderer,
 }: VirtualizedListProps<T>) {
   const loadMoreRows = async () => {
-    if (isFetching) return;
+    if (isLoading) return;
     if (!hasNextPage) return;
 
     loadMore();
@@ -46,7 +44,7 @@ export function VirtualizedList<T>({
               ref={registerChild}
               width={width}
               height={height}
-              rowCount={isFetching ? data.length + 20 : data.length}
+              rowCount={isLoading ? data.length + 20 : data.length}
               rowHeight={rowHeight}
               rowRenderer={({ index, key, style }) => {
                 const item = data[index];

--- a/src/trpc/routers/threadRouter.ts
+++ b/src/trpc/routers/threadRouter.ts
@@ -22,6 +22,10 @@ export const threadRouter = router({
         searchQuery: z.string().trim().optional(),
         cursor: z.string().optional(),
         limit: z.number().min(1).max(100).optional(),
+        sort: z.object({
+          type: z.union([z.literal("createdAt"), z.literal("lastPostedAt")]),
+          direction: z.union([z.literal("asc"), z.literal("desc")]),
+        }),
       })
     )
     .query(async ({ input, ctx }) => {
@@ -30,6 +34,7 @@ export const threadRouter = router({
         searchQuery: input.searchQuery,
         cursor: input.cursor,
         limit: input.limit || 10,
+        sort: input.sort,
       });
     }),
 

--- a/src/trpc/usecases/dashboard/ListThreadsUseCase/index.ts
+++ b/src/trpc/usecases/dashboard/ListThreadsUseCase/index.ts
@@ -8,11 +8,16 @@ export class ListThreadsUseCase {
     searchQuery,
     cursor,
     limit = 10,
+    sort,
   }: {
     userId: User["id"];
     searchQuery?: string;
     cursor?: string;
     limit?: number;
+    sort: {
+      type: "createdAt" | "lastPostedAt";
+      direction: "asc" | "desc";
+    };
   }) {
     // whereの条件を生成
     const where = this.generateWhere(userId, searchQuery);
@@ -27,6 +32,7 @@ export class ListThreadsUseCase {
         id: true,
         title: true,
         createdAt: true,
+        lastPostedAt: true,
         _count: {
           select: {
             posts: {
@@ -45,7 +51,7 @@ export class ListThreadsUseCase {
         },
       },
       orderBy: {
-        createdAt: "desc",
+        [sort.type]: sort.direction,
       },
       take: limit + 1, // 次のページがあるか確認するために 1 つ多く取得
       ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}), // カーソルがある場合はスキップ

--- a/src/trpc/usecases/threadDetail/CreatePostInDetailUseCase/index.ts
+++ b/src/trpc/usecases/threadDetail/CreatePostInDetailUseCase/index.ts
@@ -22,6 +22,13 @@ export class CreatePostInDetailUseCase {
       },
     });
 
+    await prisma.thread.update({
+      where: { id: threadId },
+      data: {
+        lastPostedAt: new Date(),
+      },
+    });
+
     return { createdPost };
   }
 }

--- a/src/types/src/domains/inputTypeSchemas/ThreadScalarFieldEnumSchema.ts
+++ b/src/types/src/domains/inputTypeSchemas/ThreadScalarFieldEnumSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const ThreadScalarFieldEnumSchema = z.enum(['id','userId','title','isPublic','createdAt','updatedAt']);
+export const ThreadScalarFieldEnumSchema = z.enum(['id','userId','title','isPublic','createdAt','updatedAt','lastPostedAt']);
 
 export default ThreadScalarFieldEnumSchema;

--- a/src/types/src/domains/modelSchema/ThreadSchema.ts
+++ b/src/types/src/domains/modelSchema/ThreadSchema.ts
@@ -11,6 +11,7 @@ export const ThreadSchema = z.object({
   isPublic: z.boolean(),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
+  lastPostedAt: z.coerce.date(),
 })
 
 export type Thread = z.infer<typeof ThreadSchema>


### PR DESCRIPTION
Related to #91

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itizawa/thread-note/pull/92?shareId=1fd4728d-8d30-4cf4-a954-4b41ff198396).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic thread sorting. Users can now choose to view threads ordered by either their creation time or most recent update.
  - A new selection option in the thread list allows immediate adjustment of the sorting order, enhancing the browsing experience.
  - Added a new field to track the last time a post was made in each thread.
  - Implemented automatic updates to the last activity timestamp of threads upon new posts.
  - Enhanced query performance with a new index on the user ID in the threads table. 

- **Bug Fixes**
  - Streamlined loading state management by consolidating `isLoading` and `isFetching` into a single prop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->