### PR TITLE
Add emoji icons to threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "client-only": "^0.0.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "emoji-picker-react": "^4.12.2",
     "lucide-react": "^0.482.0",
     "next": "^15.2.2",
     "next-auth": "^5.0.0-beta.25",

--- a/src/components/feature/dashboard/SidebarThreadList/index.tsx
+++ b/src/components/feature/dashboard/SidebarThreadList/index.tsx
@@ -65,7 +65,7 @@ function PostListItem({ thread }: { thread: Thread }) {
     <Link href={urls.dashboardThreadDetails(thread.id)}>
       <div className="flex items-center justify-between rounded-lg gap-4 p-2 hover:bg-gray-100 cursor-pointer">
         <span className="text-sm truncate max-w-xs">
-          {thread.title || "タイトルなし"}
+          {thread.emoji} {thread.title || "タイトルなし"}
         </span>
       </div>
     </Link>

--- a/src/components/feature/dashboard/ThreadList/index.tsx
+++ b/src/components/feature/dashboard/ThreadList/index.tsx
@@ -153,7 +153,7 @@ function PostListItem({ thread }: { thread: Thread }) {
           <div className="flex items-center justify-between gap-2 overflow-x-hidden">
             <div className="overflow-x-hidden relative">
               <span className="block w-full font-bold truncate">
-                {thread.title || "タイトルなし"}
+                {thread.emoji} {thread.title || "タイトルなし"}
               </span>
               <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                 {format(new Date(thread.createdAt), "yyyy/MM/dd HH:mm")}

--- a/src/components/feature/threadDetail/ThreadInformation/index.tsx
+++ b/src/components/feature/threadDetail/ThreadInformation/index.tsx
@@ -19,6 +19,7 @@ import { useServerAction } from "@/lib/useServerAction";
 import { trpc } from "@/trpc/client";
 import { Pencil } from "lucide-react";
 import { useState } from "react";
+import { EmojiIconPicker } from "@/components/ui/emojiIconPicker"; // P5c34
 
 export function ThreadInformation({ threadId }: { threadId: string }) {
   const utils = trpc.useUtils();
@@ -31,6 +32,7 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
     id: threadId,
   });
   const [title, setTitle] = useState("");
+  const [emoji, setEmoji] = useState(""); // P5c34
   const [isEditing, setIsEditing] = useState(false);
 
   const disabled = !title || isPending;
@@ -41,6 +43,7 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
         await updateThreadInfo({
           id: threadId,
           title,
+          emoji, // P3b24
         });
       },
       error: {
@@ -124,6 +127,7 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
             onKeyDown={handleKeyPress}
             forceFocus
           />
+          <EmojiIconPicker onSelect={setEmoji} /> {/* P5c34 */}
           <Button
             size="sm"
             className="h-9"
@@ -145,7 +149,9 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
         </div>
       ) : (
         <div className="flex items-center justify-between">
-          <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+          <h3 className="font-bold">
+            {threadInfo.emoji} {threadInfo.title || "タイトルなし"} {/* P7d2a */}
+          </h3>
           <Button variant="ghost" onClick={() => setIsEditing(true)}>
             <Pencil className="h-4 w-4" />
           </Button>

--- a/src/trpc/routers/threadRouter.ts
+++ b/src/trpc/routers/threadRouter.ts
@@ -60,7 +60,7 @@ export const threadRouter = router({
     }),
 
   updateThreadInfo: protectedProcedure
-    .input(ThreadSchema.pick({ id: true, title: true }))
+    .input(ThreadSchema.pick({ id: true, title: true, emoji: true }))
     .mutation(async ({ ctx, input }) => {
       return await prisma.thread.update({
         where: {
@@ -69,6 +69,7 @@ export const threadRouter = router({
         },
         data: {
           title: input.title,
+          emoji: input.emoji,
         },
       });
     }),
@@ -165,12 +166,14 @@ export const threadRouter = router({
       z.object({
         body: PostSchema.shape.body.optional(),
         title: ThreadSchema.shape.title,
+        emoji: ThreadSchema.shape.emoji.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       return await createThreadWithFIrstPostUseCase.execute({
         postBody: input.body,
         title: input.title,
+        emoji: input.emoji,
         currentUser: ctx.currentUser,
       });
     }),

--- a/src/trpc/usecases/newThread/CreateThreadWithFIrstPostUseCase/index.ts
+++ b/src/trpc/usecases/newThread/CreateThreadWithFIrstPostUseCase/index.ts
@@ -5,15 +5,18 @@ export class CreateThreadWithFIrstPostUseCase {
   async execute({
     postBody,
     title,
+    emoji,
     currentUser,
   }: {
     postBody?: Post["body"];
     title?: Thread["title"];
+    emoji?: Thread["emoji"];
     currentUser: User;
   }): Promise<{ thread: Thread }> {
     const thread = await prisma.thread.create({
       data: {
         title,
+        emoji,
         posts: {
           create: postBody
             ? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,13 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+emoji-picker-react@^4.12.2:
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/emoji-picker-react/-/emoji-picker-react-4.12.2.tgz#323fbbf763daf1ffc1a9ff819966408e1ec30bab"
+  integrity sha512-6PDYZGlhidt+Kc0ay890IU4HLNfIR7/OxPvcNxw+nJ4HQhMKd8pnGnPn4n2vqC/arRFCNWQhgJP8rpsYKsz0GQ==
+  dependencies:
+    flairup "1.0.0"
+
 emoji-regex@^10.2.1:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
@@ -3008,6 +3015,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+flairup@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/flairup/-/flairup-1.0.0.tgz#d3af0052ad02734c12d2446608a869498adb351b"
+  integrity sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==
 
 flat-cache@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
Related to #93

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itizawa/thread-note/pull/94?shareId=1f63de46-ff58-4fc2-a0ac-31e2ee7e9407).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced thread listings now show an emoji before each thread title for improved visual appeal.
  - Added an emoji picker in thread details, allowing users to select an emoji when editing thread information.
  - Updated thread creation and update processes to support including an emoji alongside the thread title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->