### PR TITLE
Add hash links for thread IDs

### DIFF
--- a/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
@@ -7,22 +7,20 @@ import {
 } from "@/shared/ui/dropdown-menu";
 import { Tooltip } from "@/shared/ui/Tooltip";
 
-import { Archive, MoreHorizontal, Pencil } from "lucide-react";
+import { Archive, Link, MoreHorizontal, Pencil } from "lucide-react";
 
 type Props = {
   isPending: boolean;
-  isArchived: boolean;
   onClickEditButton: () => void;
+  onClickShareButton?: () => void;
   onClickArchiveButton: () => void;
-  onClickUnArchiveButton: () => void;
 };
 
 export function ManagePostDropDown({
   isPending,
-  isArchived,
   onClickEditButton,
+  onClickShareButton,
   onClickArchiveButton,
-  onClickUnArchiveButton,
 }: Props) {
   return (
     <DropdownMenu>
@@ -35,28 +33,21 @@ export function ManagePostDropDown({
         </Tooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {!isArchived && (
-          <DropdownMenuItem onClick={onClickEditButton}>
-            <Pencil className="h-4 w-4" />
-            編集
-          </DropdownMenuItem>
-        )}
-        {!isArchived && (
-          <DropdownMenuItem
-            onClick={onClickArchiveButton}
-            className="text-destructive focus:text-destructive"
-          >
-            <Archive className="h-4 w-4" />
-            アーカイブ
-          </DropdownMenuItem>
-        )}
-        {isArchived && (
-          <DropdownMenuItem
-            onClick={onClickUnArchiveButton}
-            className="text-destructive focus:text-destructive"
-          >
-            <Archive className="h-4 w-4" />
-            アーカイブを取り消す
+        <DropdownMenuItem onClick={onClickEditButton}>
+          <Pencil className="h-4 w-4" />
+          編集
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={onClickArchiveButton}
+          className="text-destructive focus:text-destructive"
+        >
+          <Archive className="h-4 w-4" />
+          アーカイブ
+        </DropdownMenuItem>
+        {onClickShareButton && (
+          <DropdownMenuItem onClick={onClickShareButton}>
+            <Link className="mr-2 h-4 w-4" />
+            共有リンクをコピー
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>

--- a/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
@@ -37,6 +37,12 @@ export function ManagePostDropDown({
           <Pencil className="h-4 w-4" />
           編集
         </DropdownMenuItem>
+        {onClickShareButton && (
+          <DropdownMenuItem onClick={onClickShareButton}>
+            <Link className="mr-2 h-4 w-4" />
+            共有リンクをコピー
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem
           onClick={onClickArchiveButton}
           className="text-destructive focus:text-destructive"
@@ -44,12 +50,6 @@ export function ManagePostDropDown({
           <Archive className="h-4 w-4" />
           アーカイブ
         </DropdownMenuItem>
-        {onClickShareButton && (
-          <DropdownMenuItem onClick={onClickShareButton}>
-            <Link className="mr-2 h-4 w-4" />
-            共有リンクをコピー
-          </DropdownMenuItem>
-        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -150,12 +150,7 @@ export function PostPaper({ post, isPublicThread }: Props) {
             <Link href={urls.userDetails(user.id)} className="hover:opacity-60">
               <div className="text-sm">{user.name}</div>
             </Link>
-            <div
-              className={`text-xs text-muted-foreground ${
-                isPublicThread ? "hover:opacity-60 cursor-pointer" : ""
-              }`}
-              onClick={isPublicThread ? handleClickPostCreatedAt : undefined}
-            >
+            <div className={`text-xs text-muted-foreground`}>
               <time>
                 {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
               </time>
@@ -165,10 +160,11 @@ export function PostPaper({ post, isPublicThread }: Props) {
         {!isEditing && !post.isArchived && (
           <ManagePostDropDown
             isPending={isPending}
-            isArchived={post.isArchived}
             onClickEditButton={() => setIsEditing(true)}
+            onClickShareButton={
+              isPublicThread ? handleClickPostCreatedAt : undefined
+            }
             onClickArchiveButton={handleClickArchiveButton}
-            onClickUnArchiveButton={handleClickUnArchiveButton}
           />
         )}
       </div>

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -107,7 +107,8 @@ export function PostPaper({ post, isPublicThread }: Props) {
       urlJoin(
         window.location.origin,
         urls.threadDetails(post.threadId, post.id)
-      )
+      ),
+      "共有URLをコピーしました"
     );
   };
 

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -137,7 +137,9 @@ export function PostPaper({ post }: Props) {
               <div className="text-sm">{user.name}</div>
             </Link>
             <div className="text-xs text-muted-foreground">
-              {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
+              <time>
+                {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
+              </time>
             </div>
           </div>
         </div>

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -142,9 +142,9 @@ export function PostPaper({ post, isPublicThread }: Props) {
         <div className="flex items-center space-x-2">
           <Link
             href={urls.userDetails(user.id)}
-            className="h-8 w-8 hover:opacity-60"
+            className="h-10 w-10 hover:opacity-60"
           >
-            <UserIcon userImage={user?.image} />
+            <UserIcon userImage={user?.image} size={10} />
           </Link>
           <div>
             <Link href={urls.userDetails(user.id)} className="hover:opacity-60">

--- a/src/features/threadDetail/PostTimeLine/index.tsx
+++ b/src/features/threadDetail/PostTimeLine/index.tsx
@@ -71,7 +71,13 @@ const PostTimeLineCore = ({
   return (
     <div className="w-full flex-col space-y-4 overflow-y-auto pb-10">
       {threadWithPosts.posts.map((v) => {
-        return <PostPaper key={v.id} post={v} />;
+        return (
+          <PostPaper
+            key={v.id}
+            post={v}
+            isPublicThread={threadWithPosts.isPublic}
+          />
+        );
       })}
 
       <CreateNewPostForm threadId={threadId} />

--- a/src/features/threadDetail/PublicPostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PublicPostPaper/ManagePostDropDown/index.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+import { Link, MoreHorizontal } from "lucide-react";
+
+type Props = {
+  onClickShareButton: () => void;
+};
+
+export function ManagePostDropDown({ onClickShareButton }: Props) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <MoreHorizontal className="h-4 w-4" />
+          <span className="sr-only">メニューを開く</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onClickShareButton}>
+          <Link className="mr-2 h-4 w-4" />
+          リンクをコピー
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/features/threadDetail/PublicPostPaper/index.tsx
+++ b/src/features/threadDetail/PublicPostPaper/index.tsx
@@ -14,15 +14,16 @@ type Post = NonNullable<
 
 interface Props {
   post: Post | Post["children"][number];
+  onClickScrollTarget: (scrollId: string) => void;
 }
 
-export function PublicPostPaper({ post }: Props) {
+export function PublicPostPaper({ post, onClickScrollTarget }: Props) {
   const isParentPost = "children" in post;
   const { user } = post;
 
   return (
     <div
-      id={post.id}
+      data-scroll-id={post.id}
       className={
         isParentPost
           ? "rounded-lg border p-4 bg-white space-y-4 target:border-orange-300"
@@ -41,7 +42,11 @@ export function PublicPostPaper({ post }: Props) {
             <Link href={urls.userDetails(user.id)} className="hover:opacity-60">
               <div className="text-sm">{user.name}</div>
             </Link>
-            <a href={`#${post.id}`} className="text-xs text-muted-foreground">
+            <a
+              href={`#${post.id}`}
+              onClick={() => onClickScrollTarget(post.id)}
+              className="text-xs text-muted-foreground"
+            >
               <time>
                 {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
               </time>
@@ -63,7 +68,10 @@ export function PublicPostPaper({ post }: Props) {
                   <div className="w-[2px] h-full bg-gray-200" />
                 </div>
                 <div className="w-full pl-6">
-                  <PublicPostPaper post={childPost} />
+                  <PublicPostPaper
+                    post={childPost}
+                    onClickScrollTarget={onClickScrollTarget}
+                  />
                 </div>
               </div>
             );

--- a/src/features/threadDetail/PublicPostPaper/index.tsx
+++ b/src/features/threadDetail/PublicPostPaper/index.tsx
@@ -22,9 +22,10 @@ export function PublicPostPaper({ post }: Props) {
 
   return (
     <div
+      id={post.id}
       className={
         isParentPost
-          ? "rounded-lg border p-4 bg-white space-y-4"
+          ? "rounded-lg border p-4 bg-white space-y-4 target:border-orange-300"
           : "rounded-lg p-2 pr-0 space-y-4"
       }
     >
@@ -36,13 +37,15 @@ export function PublicPostPaper({ post }: Props) {
           >
             <UserIcon userImage={user?.image} />
           </Link>
-          <div>
+          <div className="flex flex-col space-y-1">
             <Link href={urls.userDetails(user.id)} className="hover:opacity-60">
               <div className="text-sm">{user.name}</div>
             </Link>
-            <div className="text-xs text-muted-foreground">
-              {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
-            </div>
+            <a href={`#${post.id}`} className="text-xs text-muted-foreground">
+              <time>
+                {format(new Date(post.createdAt), "yyyy/MM/dd HH:mm")}
+              </time>
+            </a>
           </div>
         </div>
       </div>

--- a/src/features/threadDetail/PublicPostPaper/index.tsx
+++ b/src/features/threadDetail/PublicPostPaper/index.tsx
@@ -48,9 +48,9 @@ export function PublicPostPaper({ post, onClickScrollTarget }: Props) {
         <div className="flex items-center space-x-2">
           <Link
             href={urls.userDetails(user.id)}
-            className="h-8 w-8 hover:opacity-60"
+            className="h-10 w-10 hover:opacity-60"
           >
-            <UserIcon userImage={user?.image} />
+            <UserIcon userImage={user?.image} size={10} />
           </Link>
           <div className="flex flex-col space-y-1">
             <Link href={urls.userDetails(user.id)} className="hover:opacity-60">

--- a/src/features/threadDetail/PublicPostPaper/index.tsx
+++ b/src/features/threadDetail/PublicPostPaper/index.tsx
@@ -2,11 +2,14 @@
 
 import { UserIcon } from "@/entities/user/UserIcon";
 import { urls } from "@/shared/consts/urls";
+import { useClipBoardCopy } from "@/shared/hooks/useClipBoardCopy";
 import { MarkdownViewer } from "@/shared/ui/MarkdownViewer";
 import { AppRouter } from "@/trpc/routers/_app";
 import { inferRouterOutputs } from "@trpc/server";
 import { format } from "date-fns";
 import Link from "next/link";
+import urlJoin from "url-join";
+import { ManagePostDropDown } from "./ManagePostDropDown";
 
 type Post = NonNullable<
   inferRouterOutputs<AppRouter>["thread"]["getPublicThreadWithPosts"]["threadWithPosts"]
@@ -20,6 +23,17 @@ interface Props {
 export function PublicPostPaper({ post, onClickScrollTarget }: Props) {
   const isParentPost = "children" in post;
   const { user } = post;
+  const { copy } = useClipBoardCopy();
+
+  const handleClickPostCreatedAt = () => {
+    copy(
+      urlJoin(
+        window.location.origin,
+        urls.threadDetails(post.threadId, post.id)
+      ),
+      "URLをコピーしました"
+    );
+  };
 
   return (
     <div
@@ -53,6 +67,7 @@ export function PublicPostPaper({ post, onClickScrollTarget }: Props) {
             </a>
           </div>
         </div>
+        <ManagePostDropDown onClickShareButton={handleClickPostCreatedAt} />
       </div>
       <div className="pb-4">
         <div className="prose space-y-4 break-words">

--- a/src/features/threadDetail/PublicPostTimeLine/index.tsx
+++ b/src/features/threadDetail/PublicPostTimeLine/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useScrollToTarget } from "@/shared/hooks/useScrollToTarget";
 import { trpc } from "@/trpc/client";
 import { AppRouter } from "@/trpc/routers/_app";
 import { inferRouterOutputs } from "@trpc/server";
@@ -13,6 +14,8 @@ export function PublicPostTimeLine({ threadId }: { threadId: string }) {
   const [{ threadWithPosts }] =
     trpc.thread.getPublicThreadWithPosts.useSuspenseQuery({ id: threadId });
 
+  const { handleScroll } = useScrollToTarget();
+
   if (!threadWithPosts) {
     return <p>投稿が見つかりませんでした。</p>;
   }
@@ -20,7 +23,13 @@ export function PublicPostTimeLine({ threadId }: { threadId: string }) {
   return (
     <div className="w-full flex-col space-y-4 overflow-y-auto pb-10">
       {threadWithPosts.posts.map((post: Post) => {
-        return <PublicPostPaper key={post.id} post={post} />;
+        return (
+          <PublicPostPaper
+            key={post.id}
+            post={post}
+            onClickScrollTarget={handleScroll}
+          />
+        );
       })}
     </div>
   );

--- a/src/features/threadDetail/PublicPostTimeLine/index.tsx
+++ b/src/features/threadDetail/PublicPostTimeLine/index.tsx
@@ -22,6 +22,9 @@ export function PublicPostTimeLine({ threadId }: { threadId: string }) {
 
   return (
     <div className="w-full flex-col space-y-4 overflow-y-auto pb-10">
+      {threadWithPosts.posts.length === 0 && (
+        <p className="text-sm text-gray-800">まだポストがありません。</p>
+      )}
       {threadWithPosts.posts.map((post: Post) => {
         return (
           <PublicPostPaper

--- a/src/features/threadDetail/PublicStatusDialog/index.tsx
+++ b/src/features/threadDetail/PublicStatusDialog/index.tsx
@@ -2,6 +2,7 @@
 
 import { updateThreadPublicStatus } from "@/app/actions/threadActions";
 import { urls } from "@/shared/consts/urls";
+import { useClipBoardCopy } from "@/shared/hooks/useClipBoardCopy";
 import { useServerAction } from "@/shared/lib/useServerAction";
 import { Button } from "@/shared/ui/button";
 import {
@@ -24,7 +25,6 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
-import { toast } from "sonner";
 import urlJoin from "url-join";
 
 interface PublicStatusDialogProps {
@@ -45,11 +45,7 @@ export function PublicStatusDialog({
     window.location.origin,
     urls.threadDetails(threadId)
   );
-
-  const handleCopyUrl = () => {
-    navigator.clipboard.writeText(threadDetailUrl);
-    toast.success("URLをコピーしました");
-  };
+  const { copy } = useClipBoardCopy();
 
   const handleClickOpenPageIcon = () => {
     window.open(threadDetailUrl, "_blank", "noopener,noreferrer");
@@ -176,7 +172,7 @@ export function PublicStatusDialog({
                         value={threadDetailUrl}
                         readOnly
                         className="cursor-pointer"
-                        onClick={handleCopyUrl}
+                        onClick={() => copy(threadDetailUrl)}
                       />
                     </div>
                   </div>

--- a/src/features/threadDetail/PublicStatusDialog/index.tsx
+++ b/src/features/threadDetail/PublicStatusDialog/index.tsx
@@ -93,8 +93,10 @@ export function PublicStatusDialog({
         text: "公開状態の更新に失敗しました",
       },
       success: {
-        onSuccess: () =>
-          utils.thread.getThreadInfo.invalidate({ id: threadId }),
+        onSuccess: () => {
+          utils.thread.getThreadInfo.invalidate({ id: threadId });
+          utils.thread.getThreadWithPosts.invalidate({ id: threadId });
+        },
         text: isPublic ? "非公開に設定しました" : "公開に設定しました",
       },
     });

--- a/src/shared/consts/size.ts
+++ b/src/shared/consts/size.ts
@@ -1,0 +1,3 @@
+export const sizeNumbers = {
+  navigationHeight: 56,
+};

--- a/src/shared/consts/urls.ts
+++ b/src/shared/consts/urls.ts
@@ -7,6 +7,7 @@ export const urls = {
   dashboardThreadDetails: (id: string) => `/dashboard/${id}`,
   dashboardSettings: (tab: "profile" | "files") =>
     `/dashboard/settings?tab=${tab}`,
-  threadDetails: (id: string) => `/${id}`,
+  threadDetails: (id: string, postId?: string) =>
+    `/${id}${postId ? `#${postId}` : ""}`,
   userDetails: (id: string) => `/users/${id}`,
 };

--- a/src/shared/hooks/useClipBoardCopy.ts
+++ b/src/shared/hooks/useClipBoardCopy.ts
@@ -1,0 +1,10 @@
+import { toast } from "sonner";
+
+export const useClipBoardCopy = () => {
+  const copy = (url: string) => {
+    navigator.clipboard.writeText(url);
+    toast.success("URLをコピーしました");
+  };
+
+  return { copy };
+};

--- a/src/shared/hooks/useClipBoardCopy.ts
+++ b/src/shared/hooks/useClipBoardCopy.ts
@@ -1,9 +1,9 @@
 import { toast } from "sonner";
 
 export const useClipBoardCopy = () => {
-  const copy = (url: string) => {
+  const copy = (url: string, text: string = "URLをコピーしました") => {
     navigator.clipboard.writeText(url);
-    toast.success("URLをコピーしました");
+    toast.success(text);
   };
 
   return { copy };

--- a/src/shared/hooks/useScrollToTarget.ts
+++ b/src/shared/hooks/useScrollToTarget.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { sizeNumbers } from "../consts/size";
+
+export const useScrollToTarget = () => {
+  const handleScroll = (scrollId: string) => {
+    const element = document.querySelector(`[data-scroll-id="${scrollId}"]`);
+    if (element) {
+      const elementPosition =
+        element.getBoundingClientRect().top + window.scrollY;
+      window.scrollTo({
+        top: elementPosition - sizeNumbers.navigationHeight - 16, // Navigationに加えて余裕を持って16px開けている
+        behavior: "smooth",
+      });
+    }
+  };
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash) return;
+    const scrollId = hash.substring(1); // `#section1` → `section1`
+    handleScroll(scrollId);
+  }, []);
+
+  return { handleScroll };
+};


### PR DESCRIPTION
Fixes #124

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/itizawa/thread-note/pull/126?shareId=6d680aa1-f640-46c6-a4b8-f64df8ed1ab3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new prop for the `PostPaper` component to conditionally display timestamps based on thread visibility.
  - Added functionality to copy thread URLs to the clipboard via clickable timestamps.
  - Improved interactivity in the `PublicPostPaper` component with scroll target functionality.
  - Added a new dropdown menu for managing post actions, including a share link option.
  - Introduced a new hook for clipboard copying functionality.
  - Enhanced the `ManagePostDropDown` component with a share link feature.
  - Added a new `ManagePostDropDown` component in the `PublicPostPaper` for improved post management.

- **Style**
  - Enhanced post detail layouts with semantic markup and improved visual elements for better user engagement.
  - Updated styling for the parent post's container to reflect target states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->