### PR TITLE
アーカイブしたポストを表示する動線を用意した

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -1,13 +1,10 @@
 import { getCurrentUser } from "@/app/actions/userActions";
 import { PostTimeLine } from "@/features/threadDetail/PostTimeLine";
-import { ThreadInformation } from "@/features/threadDetail/ThreadInformation";
 import { urls } from "@/shared/consts/urls";
 import { generateMetadataObject } from "@/shared/lib/generateMetadataObject";
-import { Skeleton } from "@/shared/ui/skeleton";
 import { trpc } from "@/trpc/server";
 import { Metadata, NextSegmentPage } from "next";
 import { redirect } from "next/navigation";
-import { Suspense } from "react";
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -44,13 +41,8 @@ export default async function Page({ params }: Props) {
   return (
     <div className="h-full relative">
       <main className="w-full overflow-y-auto border-r md:px-6 px-2 md:pt-6 pt-4 pb-4">
-        <div className="w-full max-w-[700px] mx-auto space-y-4">
-          <ThreadInformation threadId={threadId} />
-          <div className="overflow-y-auto">
-            <Suspense fallback={<Skeleton className="w-full h-20" />}>
-              <PostTimeLine threadId={threadId} />
-            </Suspense>
-          </div>
+        <div className="w-full max-w-[700px] mx-auto">
+          <PostTimeLine threadId={threadId} />
         </div>
       </main>
 

--- a/src/features/dashboard/DashBoardSidebar/index.tsx
+++ b/src/features/dashboard/DashBoardSidebar/index.tsx
@@ -41,7 +41,7 @@ export const DashBoardSidebar = async () => {
               className="ml-auto"
             >
               <Tooltip content="ユーザーページを開く">
-                <Button size="icon" variant="link">
+                <Button variant="ghost" size="icon">
                   <SquareArrowOutUpRight className="h-4 w-4" />
                 </Button>
               </Tooltip>

--- a/src/features/dashboard/ThreadList/index.tsx
+++ b/src/features/dashboard/ThreadList/index.tsx
@@ -104,7 +104,7 @@ export function ThreadList() {
 function PostListItemSkeleton() {
   return (
     <div className="flex items-center gap-4 p-4">
-      <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+      <div className="w-10 h-10 bg-gray-200 rounded-full"></div>
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-center justify-between gap-2">
           <div className="flex flex-col gap-2">

--- a/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
@@ -12,18 +12,20 @@ import { Archive, MoreHorizontal, Pencil } from "lucide-react";
 type Props = {
   isPending: boolean;
   onClickEditButton: () => void;
-  onClickArchiveButton: () => void;
+  onClickArchiveButton?: () => void;
+  onClickUnArchiveButton?: () => void;
 };
 
 export function ManagePostDropDown({
   isPending,
   onClickEditButton,
   onClickArchiveButton,
+  onClickUnArchiveButton,
 }: Props) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>
-        <Tooltip content="スレッドを操作">
+        <Tooltip content="ポストを操作">
           <Button variant="ghost" size="icon" disabled={isPending}>
             <MoreHorizontal className="h-4 w-4" />
             <span className="sr-only">メニューを開く</span>
@@ -35,13 +37,24 @@ export function ManagePostDropDown({
           <Pencil className="h-4 w-4" />
           編集
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={onClickArchiveButton}
-          className="text-destructive focus:text-destructive"
-        >
-          <Archive className="h-4 w-4" />
-          アーカイブ
-        </DropdownMenuItem>
+        {onClickArchiveButton && (
+          <DropdownMenuItem
+            onClick={onClickArchiveButton}
+            className="text-destructive focus:text-destructive"
+          >
+            <Archive className="h-4 w-4" />
+            アーカイブ
+          </DropdownMenuItem>
+        )}
+        {onClickUnArchiveButton && (
+          <DropdownMenuItem
+            onClick={onClickUnArchiveButton}
+            className="text-destructive focus:text-destructive"
+          >
+            <Archive className="h-4 w-4" />
+            アーカイブを取り消す
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
@@ -11,13 +11,15 @@ import { Archive, MoreHorizontal, Pencil } from "lucide-react";
 
 type Props = {
   isPending: boolean;
+  isArchived: boolean;
   onClickEditButton: () => void;
-  onClickArchiveButton?: () => void;
-  onClickUnArchiveButton?: () => void;
+  onClickArchiveButton: () => void;
+  onClickUnArchiveButton: () => void;
 };
 
 export function ManagePostDropDown({
   isPending,
+  isArchived,
   onClickEditButton,
   onClickArchiveButton,
   onClickUnArchiveButton,
@@ -33,11 +35,13 @@ export function ManagePostDropDown({
         </Tooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={onClickEditButton}>
-          <Pencil className="h-4 w-4" />
-          編集
-        </DropdownMenuItem>
-        {onClickArchiveButton && (
+        {!isArchived && (
+          <DropdownMenuItem onClick={onClickEditButton}>
+            <Pencil className="h-4 w-4" />
+            編集
+          </DropdownMenuItem>
+        )}
+        {!isArchived && (
           <DropdownMenuItem
             onClick={onClickArchiveButton}
             className="text-destructive focus:text-destructive"
@@ -46,7 +50,7 @@ export function ManagePostDropDown({
             アーカイブ
           </DropdownMenuItem>
         )}
-        {onClickUnArchiveButton && (
+        {isArchived && (
           <DropdownMenuItem
             onClick={onClickUnArchiveButton}
             className="text-destructive focus:text-destructive"

--- a/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
+++ b/src/features/threadDetail/PostPaper/ManagePostDropDown/index.tsx
@@ -32,14 +32,14 @@ export function ManagePostDropDown({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={onClickEditButton}>
-          <Pencil className="mr-2 h-4 w-4" />
+          <Pencil className="h-4 w-4" />
           編集
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={onClickArchiveButton}
           className="text-destructive focus:text-destructive"
         >
-          <Archive className="mr-2 h-4 w-4" />
+          <Archive className="h-4 w-4" />
           アーカイブ
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -131,7 +131,12 @@ export function PostPaper({ post }: Props) {
           <ManagePostDropDown
             isPending={isPending}
             onClickEditButton={() => setIsEditing(true)}
-            onClickArchiveButton={handleClickArchiveButton}
+            onClickArchiveButton={
+              post.isArchived ? undefined : handleClickArchiveButton
+            }
+            onClickUnArchiveButton={
+              post.isArchived ? handleClickUnArchiveButton : undefined
+            }
           />
         )}
       </div>

--- a/src/features/threadDetail/PostPaper/index.tsx
+++ b/src/features/threadDetail/PostPaper/index.tsx
@@ -130,13 +130,10 @@ export function PostPaper({ post }: Props) {
         {!isEditing && (
           <ManagePostDropDown
             isPending={isPending}
+            isArchived={post.isArchived}
             onClickEditButton={() => setIsEditing(true)}
-            onClickArchiveButton={
-              post.isArchived ? undefined : handleClickArchiveButton
-            }
-            onClickUnArchiveButton={
-              post.isArchived ? handleClickUnArchiveButton : undefined
-            }
+            onClickArchiveButton={handleClickArchiveButton}
+            onClickUnArchiveButton={handleClickUnArchiveButton}
           />
         )}
       </div>

--- a/src/features/threadDetail/PostTimeLine/index.tsx
+++ b/src/features/threadDetail/PostTimeLine/index.tsx
@@ -1,14 +1,65 @@
 "use client";
 
+import { urls } from "@/shared/consts/urls";
+import { Skeleton } from "@/shared/ui/skeleton";
 import { trpc } from "@/trpc/client";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Suspense, useState } from "react";
 import { CreateNewPostForm } from "../CreateNewPostForm";
 import { PostPaper } from "../PostPaper";
+import { ThreadInformation } from "../ThreadInformation";
 
 export function PostTimeLine({ threadId }: { threadId: string }) {
+  const [includeIsArchived, setIncludeIsArchived] = useState(false);
+
+  const toggleIncludeIsArchived = () => {
+    setIncludeIsArchived((prev) => !prev);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Suspense
+        fallback={
+          <div className="space-y-4">
+            <Link
+              href={urls.dashboard}
+              className="flex space-x-1 items-center text-gray-700"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span className="text-xs">Home</span>
+            </Link>
+            <Skeleton className="w-full h-9" />
+          </div>
+        }
+      >
+        <ThreadInformation
+          threadId={threadId}
+          includeIsArchived={includeIsArchived}
+          toggleIncludeIsArchived={toggleIncludeIsArchived}
+        />
+      </Suspense>
+      <Suspense fallback={<Skeleton className="w-full h-20" />}>
+        <PostTimeLineCore
+          threadId={threadId}
+          includeIsArchived={includeIsArchived}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+const PostTimeLineCore = ({
+  threadId,
+  includeIsArchived,
+}: {
+  threadId: string;
+  includeIsArchived: boolean;
+}) => {
   const [{ threadWithPosts }] = trpc.thread.getThreadWithPosts.useSuspenseQuery(
     {
       id: threadId,
-      includeIsArchived: false,
+      includeIsArchived,
     }
   );
 
@@ -26,4 +77,4 @@ export function PostTimeLine({ threadId }: { threadId: string }) {
       <CreateNewPostForm threadId={threadId} />
     </div>
   );
-}
+};

--- a/src/features/threadDetail/ThreadInformation/ManageThreadDropDown/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/ManageThreadDropDown/index.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+import { Archive, MoreHorizontal } from "lucide-react";
+
+type Props = {
+  includeIsArchived: boolean;
+  onClickToggleDisplayArchiveButton: () => void;
+};
+
+export function ManageThreadDropDown({
+  includeIsArchived,
+  onClickToggleDisplayArchiveButton,
+}: Props) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="hover:bg-gray-200">
+          <MoreHorizontal className="h-4 w-4" />
+          <span className="sr-only">メニューを開く</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onClickToggleDisplayArchiveButton}>
+          <Archive className="h-4 w-4" />
+          {includeIsArchived ? "アーカイブの非表示" : "アーカイブの表示"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/features/threadDetail/ThreadInformation/ManageThreadDropDown/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/ManageThreadDropDown/index.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
+import { Tooltip } from "@/shared/ui/Tooltip";
 
 import { Archive, MoreHorizontal } from "lucide-react";
 
@@ -19,11 +20,13 @@ export function ManageThreadDropDown({
 }: Props) {
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="hover:bg-gray-200">
-          <MoreHorizontal className="h-4 w-4" />
-          <span className="sr-only">メニューを開く</span>
-        </Button>
+      <DropdownMenuTrigger>
+        <Tooltip content="スレッドを操作">
+          <Button variant="ghost" size="icon" className="hover:bg-gray-200">
+            <MoreHorizontal className="h-4 w-4" />
+            <span className="sr-only">メニューを開く</span>
+          </Button>
+        </Tooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={onClickToggleDisplayArchiveButton}>

--- a/src/features/threadDetail/ThreadInformation/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/index.tsx
@@ -115,12 +115,13 @@ export function ThreadInformation({
           </Button>
         </div>
       ) : (
-        <div className="flex items-center justify-between group">
+        <div className="flex items-center justify-between">
           <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
           <Tooltip content="編集">
             <Button
               variant="ghost"
-              className="md:opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+              size="icon"
+              className="transition-opacity hover:bg-gray-200"
               onClick={() => setIsEditing(true)}
             >
               <Pencil className="h-4 w-4" />

--- a/src/features/threadDetail/ThreadInformation/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/index.tsx
@@ -79,7 +79,7 @@ export function ThreadInformation({
     <div className="space-y-4">
       <Link
         href={urls.dashboard}
-        className="flex space-x-1 items-center text-gray-700"
+        className="flex space-x-1 items-center text-gray-700 hover:opacity-60"
       >
         <ArrowLeft className="w-4 h-4" />
         <span className="text-xs">一覧に戻る</span>

--- a/src/features/threadDetail/ThreadInformation/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/index.tsx
@@ -126,10 +126,14 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
           </Button>
         </div>
       ) : (
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between group">
           <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
           <Tooltip content="編集">
-            <Button variant="ghost" onClick={() => setIsEditing(true)}>
+            <Button
+              variant="ghost"
+              className="md:opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+              onClick={() => setIsEditing(true)}
+            >
               <Pencil className="h-4 w-4" />
             </Button>
           </Tooltip>

--- a/src/features/userPage/ThreadList/index.tsx
+++ b/src/features/userPage/ThreadList/index.tsx
@@ -56,7 +56,7 @@ export function ThreadList({ userId }: { userId: string }) {
 function PostListItemSkeleton() {
   return (
     <div className="flex items-center gap-4 p-4">
-      <div className="w-8 h-8 bg-gray-200 rounded-full"></div>
+      <div className="w-10 h-10 bg-gray-200 rounded-full"></div>
       <div className="flex flex-1 flex-col gap-1">
         <div className="flex items-center justify-between gap-2">
           <div className="flex flex-col gap-2">

--- a/src/shared/ui/MarkdownViewer/index.tsx
+++ b/src/shared/ui/MarkdownViewer/index.tsx
@@ -14,12 +14,10 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
           <h1 className="text-3xl font-bold border-b pb-2">{children}</h1>
         ),
         h2: ({ children }) => (
-          <h2 className="text-2xl font-semibold mt-4 border-b pb-1">
-            {children}
-          </h2>
+          <h2 className="text-2xl font-semibold border-b pb-1">{children}</h2>
         ),
         h3: ({ children }) => (
-          <h3 className="text-xl font-semibold mt-3">{children}</h3>
+          <h3 className="text-xl font-semibold">{children}</h3>
         ),
         p: ({ node, children }) => {
           const child = node?.children[0];
@@ -43,7 +41,7 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
             }
           }
 
-          return <p className="text-gray-800">{children}</p>;
+          return <p className="text-gray-900">{children}</p>;
         },
         ul: ({ children }) => (
           <ul className="list-disc ml-5 space-y-1">{children}</ul>
@@ -51,7 +49,7 @@ export const MarkdownViewer: React.FC<{ body: string }> = ({ body }) => {
         ol: ({ children }) => (
           <ol className="list-decimal ml-5 space-y-1">{children}</ol>
         ),
-        li: ({ children }) => <li className="text-gray-800">{children}</li>,
+        li: ({ children }) => <li className="text-gray-900">{children}</li>,
         blockquote: ({ children }) => (
           <blockquote className="border-l-4 border-gray-400 pl-4 italic text-gray-600">
             {children}


### PR DESCRIPTION
## 対象の Issue

Fix:

## 変更点(UI の変更があればスクリーンショットも)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an archive toggle to the thread timeline, enabling users to dynamically show or hide archived posts.
  - Introduced a management dropdown that provides quick control over the display of archived threads.
  - Enhanced the post management dropdown with options for archiving and unarchiving posts.
  - Updated the thread information component to include options for managing archived posts.
  - Improved the visual representation of archived posts with distinct background colors and opacity adjustments.

- **Refactor**
  - Streamlined the dashboard and thread layouts by removing redundant loading states and components.

- **Style**
  - Adjusted dropdown icon spacing and improved hover effects for a cleaner, more consistent interface.
  - Increased the size of skeleton loading components for better visual representation.
  - Modified margins and text colors in the Markdown viewer for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->