### PR TITLE
ForceFocus を適応して新規作成ポストに自動でスクロールするようにした

### DIFF
--- a/src/features/threadDetail/CreateNewPostForm/index.tsx
+++ b/src/features/threadDetail/CreateNewPostForm/index.tsx
@@ -74,6 +74,7 @@ export function CreateNewPostForm({ threadId }: Props) {
             value: body,
             onChange: handleContentChange,
             onKeyPress: handleKeyPress,
+            forceFocus: true,
           }}
           formState={{
             isDisabled: Boolean(isDisabled),


### PR DESCRIPTION
## 対象の Issue

Fix:

## 変更点(UI の変更があればスクリーンショットも)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The post creation form now automatically focuses the textarea when opened, making it easier to start typing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->