### PR TITLE
feat: スレッドに絵文字アイコンを設定できる機能を追加

### DIFF
--- a/prisma/migrations/20250608003500_add_emoji_icon_to_thread/migration.sql
+++ b/prisma/migrations/20250608003500_add_emoji_icon_to_thread/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "threads" ADD COLUMN "emoji_icon" VARCHAR(10);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,7 @@ model Thread {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   title String?
+  emojiIcon String? @map("emoji_icon") @db.VarChar(10)
   isPublic Boolean @default(false) @map("is_public")
   isClosed Boolean @default(false) @map("is_closed")
 

--- a/src/app/actions/threadActions.ts
+++ b/src/app/actions/threadActions.ts
@@ -18,7 +18,7 @@ export const createPostInThread = async (
   return createdPost;
 };
 
-export const updateThreadInfo = async (args: { id: string; title: string }) => {
+export const updateThreadInfo = async (args: { id: string; title: string; emojiIcon?: string | null }) => {
   await trpc.thread.updateThreadInfo(args);
 };
 

--- a/src/features/dashboard/SidebarThreadList/index.tsx
+++ b/src/features/dashboard/SidebarThreadList/index.tsx
@@ -78,7 +78,10 @@ function PostListItem({ thread }: { thread: Thread }) {
     <>
       <Link href={urls.dashboardThreadDetails(thread.id)} className="">
         <div className="flex items-center justify-between rounded-lg p-2 hover:bg-gray-100 group">
-          <div className="flex items-center cursor-pointer flex-1 min-w-0">
+          <div className="flex items-center cursor-pointer flex-1 min-w-0 gap-1">
+            {thread.emojiIcon && (
+              <span className="text-sm">{thread.emojiIcon}</span>
+            )}
             <span className="text-sm truncate max-w-xs">
               {thread.title || "タイトルなし"}
             </span>

--- a/src/features/dashboard/ThreadList/index.tsx
+++ b/src/features/dashboard/ThreadList/index.tsx
@@ -125,9 +125,14 @@ function PostListItem({ thread }: { thread: Thread }) {
         <div className="flex flex-1 flex-col gap-1 overflow-x-hidden">
           <div className="flex items-center justify-between gap-2 overflow-x-hidden">
             <div className="overflow-x-hidden relative">
-              <span className="block w-full font-bold truncate">
-                {thread.title || "タイトルなし"}
-              </span>
+              <div className="flex items-center gap-2">
+                {thread.emojiIcon && (
+                  <span className="text-lg">{thread.emojiIcon}</span>
+                )}
+                <span className="block w-full font-bold truncate">
+                  {thread.title || "タイトルなし"}
+                </span>
+              </div>
               <span className="flex flex-wrap items-center gap-0.5 text-xs text-muted-foreground">
                 {`${formatDistanceToNowStrict(new Date(thread.lastPostedAt), {
                   addSuffix: true,

--- a/src/features/newThread/CreateNewThreadForm/index.tsx
+++ b/src/features/newThread/CreateNewThreadForm/index.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { Input } from "@/shared/ui/input";
+import { EmojiPicker } from "@/shared/ui/EmojiPicker";
 import { TEMPLATES } from "./consts";
 
 import { isMacOs, isWindowsOs } from "@/shared/lib/getOs";
@@ -26,6 +27,7 @@ export function CreateNewThreadForm() {
 
   const [title, setTitle] = useState("");
   const [body, setBody] = React.useState("");
+  const [emojiIcon, setEmojiIcon] = useState<string | null>(null);
 
   const { isPending, enqueueServerAction } = useServerAction();
   const bothEmpty = title.trim().length === 0 && body.trim().length === 0;
@@ -43,6 +45,7 @@ export function CreateNewThreadForm() {
         createThreadWithFirstPost({
           title,
           body,
+          emojiIcon,
         }),
       error: {
         text: "スレッドの作成に失敗しました",
@@ -86,6 +89,11 @@ export function CreateNewThreadForm() {
           onChange={(e) => setTitle(e.target.value)}
           onKeyDown={handleKeyPress}
           forceFocus
+        />
+        <EmojiPicker
+          selectedEmoji={emojiIcon}
+          onEmojiSelect={setEmojiIcon}
+          placeholder="絵文字"
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/features/threadDetail/PublicThreadInformation/index.tsx
+++ b/src/features/threadDetail/PublicThreadInformation/index.tsx
@@ -30,7 +30,12 @@ export function PublicThreadInformation({ threadId }: { threadId: string }) {
 
   return (
     <div className="flex items-center justify-between">
-      <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+      <div className="flex items-center gap-2">
+        {threadInfo.emojiIcon && (
+          <span className="text-xl">{threadInfo.emojiIcon}</span>
+        )}
+        <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+      </div>
       {currentUser?.id === threadInfo.userId && (
         <Link href={urls.dashboardThreadDetails(threadId)}>
           <Button variant="outline" size="sm">

--- a/src/features/threadDetail/ThreadInformation/index.tsx
+++ b/src/features/threadDetail/ThreadInformation/index.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { LinkToBack } from "@/shared/ui/LinkToBack";
 import { Tooltip } from "@/shared/ui/Tooltip";
+import { EmojiPicker } from "@/shared/ui/EmojiPicker";
 import { trpc } from "@/trpc/client";
 import { Pencil } from "lucide-react";
 import { useState } from "react";
@@ -29,6 +30,7 @@ export function ThreadInformation({
     id: threadId,
   });
   const [title, setTitle] = useState(threadInfo?.title || "");
+  const [emojiIcon, setEmojiIcon] = useState(threadInfo?.emojiIcon || null);
   const [isEditing, setIsEditing] = useState(false);
 
   const disabled = !title || isPending;
@@ -39,6 +41,7 @@ export function ThreadInformation({
         await updateThreadInfo({
           id: threadId,
           title,
+          emojiIcon,
         });
       },
       error: {
@@ -84,37 +87,51 @@ export function ThreadInformation({
       <LinkToBack href={urls.dashboard} text="一覧に戻る" />
 
       {isEditing ? (
-        <div className="flex space-x-2">
-          <Input
-            defaultValue={threadInfo.title || ""}
-            placeholder="タイトルを入力してください"
-            className="bg-white shadow-none"
-            onChange={(e) => setTitle(e.target.value)}
-            onKeyDown={handleKeyPress}
-            forceFocus
-          />
-          <Button
-            size="sm"
-            className="h-9"
-            variant="outline"
-            onClick={() => setIsEditing(false)}
-            disabled={isPending}
-          >
-            キャンセル
-          </Button>
-          <Button
-            size="sm"
-            className="h-9"
-            onClick={handleUpdate}
-            disabled={disabled}
-            loading={isPending}
-          >
-            更新
-          </Button>
+        <div className="space-y-2">
+          <div className="flex space-x-2">
+            <Input
+              defaultValue={threadInfo.title || ""}
+              placeholder="タイトルを入力してください"
+              className="bg-white shadow-none flex-1"
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={handleKeyPress}
+              forceFocus
+            />
+            <EmojiPicker
+              selectedEmoji={emojiIcon}
+              onEmojiSelect={setEmojiIcon}
+              placeholder="絵文字"
+            />
+          </div>
+          <div className="flex space-x-2">
+            <Button
+              size="sm"
+              className="h-9"
+              variant="outline"
+              onClick={() => setIsEditing(false)}
+              disabled={isPending}
+            >
+              キャンセル
+            </Button>
+            <Button
+              size="sm"
+              className="h-9"
+              onClick={handleUpdate}
+              disabled={disabled}
+              loading={isPending}
+            >
+              更新
+            </Button>
+          </div>
         </div>
       ) : (
         <div className="flex items-center justify-between">
-          <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+          <div className="flex items-center gap-2">
+            {threadInfo.emojiIcon && (
+              <span className="text-xl">{threadInfo.emojiIcon}</span>
+            )}
+            <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+          </div>
           <Tooltip content="編集">
             <Button
               variant="ghost"

--- a/src/features/threadExport/ThreadInformation/index.tsx
+++ b/src/features/threadExport/ThreadInformation/index.tsx
@@ -59,7 +59,12 @@ export function ThreadInformation({ threadId }: { threadId: string }) {
       />
 
       <div className="flex items-center justify-between">
-        <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+        <div className="flex items-center gap-2">
+          {threadInfo.emojiIcon && (
+            <span className="text-xl">{threadInfo.emojiIcon}</span>
+          )}
+          <h3 className="font-bold">{threadInfo.title || "タイトルなし"}</h3>
+        </div>
         <div className="flex items-center">
           <Tooltip content="マークダウンをコピー">
             <Button

--- a/src/features/userPage/ThreadList/index.tsx
+++ b/src/features/userPage/ThreadList/index.tsx
@@ -77,9 +77,14 @@ function PostListItem({ thread }: { thread: Thread }) {
         <div className="flex flex-1 flex-col gap-1 overflow-x-hidden">
           <div className="flex items-center justify-between gap-2 overflow-x-hidden">
             <div className="overflow-x-hidden relative">
-              <span className="block w-full font-bold truncate">
-                {thread.title || "タイトルなし"}
-              </span>
+              <div className="flex items-center gap-2">
+                {thread.emojiIcon && (
+                  <span className="text-lg">{thread.emojiIcon}</span>
+                )}
+                <span className="block w-full font-bold truncate">
+                  {thread.title || "タイトルなし"}
+                </span>
+              </div>
               <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                 {`${formatDistanceToNowStrict(new Date(thread.lastPostedAt), {
                   addSuffix: true,

--- a/src/shared/ui/EmojiPicker/index.tsx
+++ b/src/shared/ui/EmojiPicker/index.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+import { Smile } from "lucide-react";
+
+const EMOJI_OPTIONS = [
+  "📝", "💡", "🚀", "⭐", "🎯", "📚", "💻", "🔥", "🌟", "📋",
+  "🏆", "💼", "🎨", "🔧", "📊", "🎪", "🎭", "🎪", "🎯", "🎲",
+  "🎸", "🎺", "🎷", "🎻", "🥁", "🎹", "🎤", "🎧", "📻", "📺",
+  "📹", "📷", "📱", "💾", "💿", "📀", "💽", "💻", "⌨️", "🖥️",
+  "🖨️", "🖱️", "🖲️", "💽", "💾", "💿", "📀", "🎮", "🕹️", "📺"
+];
+
+interface EmojiPickerProps {
+  selectedEmoji?: string | null;
+  onEmojiSelect: (emoji: string | null) => void;
+  placeholder?: string;
+}
+
+export function EmojiPicker({ selectedEmoji, onEmojiSelect, placeholder = "絵文字を選択" }: EmojiPickerProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="bg-white">
+          {selectedEmoji ? (
+            <span className="text-lg">{selectedEmoji}</span>
+          ) : (
+            <Smile className="h-4 w-4" />
+          )}
+          {placeholder}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-80 max-h-64 overflow-y-auto">
+        <DropdownMenuItem onClick={() => onEmojiSelect(null)}>
+          <span className="text-gray-500">絵文字なし</span>
+        </DropdownMenuItem>
+        <div className="grid grid-cols-8 gap-1 p-2">
+          {EMOJI_OPTIONS.map((emoji) => (
+            <DropdownMenuItem
+              key={emoji}
+              onClick={() => onEmojiSelect(emoji)}
+              className="h-8 w-8 p-0 flex items-center justify-center cursor-pointer hover:bg-gray-100"
+            >
+              <span className="text-lg">{emoji}</span>
+            </DropdownMenuItem>
+          ))}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/trpc/routers/threadRouter.ts
+++ b/src/trpc/routers/threadRouter.ts
@@ -81,6 +81,7 @@ export const threadRouter = router({
         select: {
           id: true,
           title: true,
+          emojiIcon: true,
           isPublic: true,
           isClosed: true,
           createdAt: true,
@@ -106,6 +107,7 @@ export const threadRouter = router({
         select: {
           id: true,
           title: true,
+          emojiIcon: true,
           isPublic: true,
           isClosed: true,
           createdAt: true,
@@ -120,7 +122,7 @@ export const threadRouter = router({
     }),
 
   updateThreadInfo: protectedProcedure
-    .input(ThreadSchema.pick({ id: true, title: true }))
+    .input(ThreadSchema.pick({ id: true, title: true, emojiIcon: true }))
     .mutation(async ({ ctx, input }) => {
       return await prisma.thread.update({
         where: {
@@ -129,6 +131,7 @@ export const threadRouter = router({
         },
         data: {
           title: input.title,
+          emojiIcon: input.emojiIcon,
         },
       });
     }),
@@ -301,12 +304,14 @@ export const threadRouter = router({
       z.object({
         body: PostSchema.shape.body.optional(),
         title: ThreadSchema.shape.title,
+        emojiIcon: ThreadSchema.shape.emojiIcon.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       return await createThreadWithFIrstPostUseCase.execute({
         postBody: input.body,
         title: input.title,
+        emojiIcon: input.emojiIcon,
         currentUser: ctx.currentUser,
       });
     }),

--- a/src/trpc/usecases/dashboard/ListThreadsUseCase/index.ts
+++ b/src/trpc/usecases/dashboard/ListThreadsUseCase/index.ts
@@ -95,6 +95,7 @@ export class ListThreadsUseCase {
     return {
       id: true,
       title: true,
+      emojiIcon: true,
       createdAt: true,
       lastPostedAt: true,
       _count: {

--- a/src/trpc/usecases/newThread/CreateThreadWithFIrstPostUseCase/index.ts
+++ b/src/trpc/usecases/newThread/CreateThreadWithFIrstPostUseCase/index.ts
@@ -5,15 +5,18 @@ export class CreateThreadWithFIrstPostUseCase {
   async execute({
     postBody,
     title,
+    emojiIcon,
     currentUser,
   }: {
     postBody?: Post["body"];
     title?: Thread["title"];
+    emojiIcon?: Thread["emojiIcon"];
     currentUser: User;
   }): Promise<{ thread: Thread }> {
     const thread = await prisma.thread.create({
       data: {
         title,
+        emojiIcon,
         posts: {
           create: postBody
             ? {

--- a/src/types/src/domains/modelSchema/ThreadSchema.ts
+++ b/src/types/src/domains/modelSchema/ThreadSchema.ts
@@ -8,6 +8,7 @@ export const ThreadSchema = z.object({
   id: z.string().uuid(),
   userId: z.string(),
   title: z.string().nullable(),
+  emojiIcon: z.string().nullable(),
   isPublic: z.boolean(),
   isClosed: z.boolean(),
   ogpTitle: z.string().nullable(),


### PR DESCRIPTION
## 概要
スレッドに絵文字アイコンを設定できる機能を実装しました。

## 変更内容
- Threadモデルにemoji_icon フィールドを追加
- 絵文字選択用のEmojiPickerコンポーネントを作成
- スレッド作成・編集時に絵文字を設定可能に
- 各種リストで絵文字を表示
- tRPCルーターとuse caseを更新

Closes #93

Generated with [Claude Code](https://claude.ai/code)